### PR TITLE
Restore default desktop bootflow in installer

### DIFF
--- a/src/DigitalSignage.Client.RaspberryPi/digitalsignage-client.service
+++ b/src/DigitalSignage.Client.RaspberryPi/digitalsignage-client.service
@@ -14,18 +14,20 @@ Environment="QT_LOGGING_RULES=*.debug=false"
 Environment="DISPLAY=:0"
 Environment="XAUTHORITY=/home/INSTALL_USER/.Xauthority"
 
+# CRITICAL FIX: Wait for X11 display to be ready (desktop environment)
+# Desktop (B4) boots with X11, but we need to wait for it to be fully initialized
+# This prevents "Cannot connect to X server" errors on boot
+ExecStartPre=/bin/bash -c 'echo "Waiting for X11 display server..."; for i in {1..30}; do if DISPLAY=:0 xset q &>/dev/null 2>&1; then echo "X11 ready after $i seconds"; exit 0; fi; echo "Waiting for X11... ($i/30)"; sleep 1; done; echo "WARNING: X11 not detected after 30s, continuing anyway"; exit 0'
+
 # Pre-start file checks
 ExecStartPre=/bin/bash -c 'test -f /opt/digitalsignage-client/start-with-display.sh || (echo "ERROR: start-with-display.sh not found" && exit 1)'
 ExecStartPre=/bin/bash -c 'test -x /opt/digitalsignage-client/start-with-display.sh || (echo "ERROR: start-with-display.sh not executable" && exit 1)'
 ExecStartPre=/bin/bash -c 'test -f /opt/digitalsignage-client/venv/bin/python3 || (echo "ERROR: Python venv not found" && exit 1)'
 
-# CRITICAL FIX: Start X11 without desktop environment if not running (for HDMI displays)
-# This prevents desktop terminal window from appearing over Digital Signage client
-# Two scenarios:
-#   1. X11 already running on :0 (desktop booted) → Use it directly with start-with-display.sh
-#   2. X11 not running (console boot) → Start X11 via startx with .xinitrc (no desktop)
-# The .xinitrc will execute start-with-display.sh as the ONLY GUI application
-ExecStart=/bin/bash -c 'if DISPLAY=:0 xset q &>/dev/null 2>&1; then echo "X11 detected on :0, using existing display"; exec /opt/digitalsignage-client/start-with-display.sh; else echo "No X11 detected, starting X11 without desktop via startx"; exec /usr/bin/startx /home/INSTALL_USER/.xinitrc -- :0 vt1 -nocursor; fi'
+# Start the Digital Signage client
+# LXDE autostart is configured to NOT start terminal or desktop icons
+# This ensures the Digital Signage client is the only visible application
+ExecStart=/opt/digitalsignage-client/start-with-display.sh
 
 # Cleanup
 ExecStopPost=/bin/bash -c 'pkill -f "Xvfb :99" || true'


### PR DESCRIPTION
FIX: Previous solution (console boot + startx) caused service startup failures

Problem with previous approach:
- Boot to console (B2) + startx in systemd service failed
- startx doesn't work properly as systemd service
- Service wouldn't start, terminal still visible

New approach (SIMPLE and RELIABLE):
1. Boot to Desktop (B4) - X11 starts reliably
2. Disable terminal + desktop icons via LXDE autostart config
3. Simple systemd service - just wait for X11 and start client

Changes:
- install.sh: Back to B4 boot, configure LXDE autostart to disable terminal
- install.sh: Disable PCManFM desktop icons
- digitalsignage-client.service: Simple X11 wait + client start (no startx)

Result:
- Desktop boots normally with X11
- LXDE autostart: NO terminal, NO desktop icons
- Digital Signage client starts fullscreen as ONLY visible app

Testing:
sudo ./install.sh → sudo reboot
Expected: Black screen with Digital Signage fullscreen, no terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)