### PR TITLE
Fix IndentationError in web_interface.py

### DIFF
--- a/src/DigitalSignage.Client.RaspberryPi/web_interface.py
+++ b/src/DigitalSignage.Client.RaspberryPi/web_interface.py
@@ -540,18 +540,18 @@ class WebInterface:
                             if len(parts) >= 4:
                                 timestamp = parts[0]
                                 log_level = parts[2]
-                                    message = parts[3]
-                                else:
-                                    timestamp = datetime.now().isoformat()
-                                    log_level = 'INFO'
-                                    message = line
+                                message = parts[3]
+                            else:
+                                timestamp = datetime.now().isoformat()
+                                log_level = 'INFO'
+                                message = line
 
-                                log_entries.append({
-                                    'timestamp': timestamp,
-                                    'level': log_level,
-                                    'message': message
-                                })
-                            except Exception as parse_error:
+                            log_entries.append({
+                                'timestamp': timestamp,
+                                'level': log_level,
+                                'message': message
+                            })
+                        except Exception as parse_error:
                                 # If parsing fails, add the raw line
                                 log_entries.append({
                                     'timestamp': datetime.now().isoformat(),


### PR DESCRIPTION
CRITICAL FIX: Python syntax error preventing client startup

Problem:
- IndentationError at line 543 in web_interface.py
- 'message = parts[3]' had incorrect indentation
- 'else' clause was wrongly indented under 'if'

Solution:
- Fixed indentation in log parsing code
- 'message = parts[3]' now correctly aligned with 'timestamp' and 'log_level'
- 'else' now at same level as 'if'
- 'log_entries.append()' moved outside if/else block

This was preventing the client from even starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)