### PR TITLE
Remove BOM from install.sh to fix execution error

### DIFF
--- a/src/DigitalSignage.Client.RaspberryPi/install.sh
+++ b/src/DigitalSignage.Client.RaspberryPi/install.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Digital Signage Client - Smart Installer & Updater
 # Usage: sudo ./install.sh


### PR DESCRIPTION
CRITICAL FIX: Shell script had UTF-8 BOM preventing execution

Problem:
- install.sh had UTF-8 Byte Order Mark (BOM)
- Caused '#!/bin/bash: not found' error
- Shell couldn't parse the shebang line

Root Cause:
- File was edited in Windows editor that added BOM
- BOM (0xEF 0xBB 0xBF) is invisible but breaks shell scripts

Solution:
- Removed BOM from install.sh using sed
- File now pure UTF-8 without BOM
- Verified with 'file' command

This allows install.sh to execute properly on Raspberry Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)