### PR TITLE
Fix indentation in web_interface.py log parsing loop

### DIFF
--- a/src/DigitalSignage.Client.RaspberryPi/web_interface.py
+++ b/src/DigitalSignage.Client.RaspberryPi/web_interface.py
@@ -530,28 +530,28 @@ class WebInterface:
                             if not line:
                                 continue
 
-                        # Filter by level if specified
-                        if level != 'ALL' and level not in line:
-                            continue
+                            # Filter by level if specified
+                            if level != 'ALL' and level not in line:
+                                continue
 
-                        # Parse log line: "2025-11-17 01:02:05,974 - status_screen - DEBUG - Message"
-                        try:
-                            parts = line.split(' - ', 3)
-                            if len(parts) >= 4:
-                                timestamp = parts[0]
-                                log_level = parts[2]
-                                message = parts[3]
-                            else:
-                                timestamp = datetime.now().isoformat()
-                                log_level = 'INFO'
-                                message = line
+                            # Parse log line: "2025-11-17 01:02:05,974 - status_screen - DEBUG - Message"
+                            try:
+                                parts = line.split(' - ', 3)
+                                if len(parts) >= 4:
+                                    timestamp = parts[0]
+                                    log_level = parts[2]
+                                    message = parts[3]
+                                else:
+                                    timestamp = datetime.now().isoformat()
+                                    log_level = 'INFO'
+                                    message = line
 
-                            log_entries.append({
-                                'timestamp': timestamp,
-                                'level': log_level,
-                                'message': message
-                            })
-                        except Exception as parse_error:
+                                log_entries.append({
+                                    'timestamp': timestamp,
+                                    'level': log_level,
+                                    'message': message
+                                })
+                            except Exception as parse_error:
                                 # If parsing fails, add the raw line
                                 log_entries.append({
                                     'timestamp': datetime.now().isoformat(),


### PR DESCRIPTION
CRITICAL FIX: Loop body was outside the loop causing SyntaxError

Problem:
- SyntaxError: 'continue' not properly in loop at line 535
- Log parsing code (lines 533-560) was OUTSIDE the for-loop
- Should have been INSIDE the loop

Root Cause:
- Incorrect indentation after 'for line in recent_lines:'
- Filter and parsing logic was dedented too far
- Python saw 'continue' statement outside of any loop

Solution:
- Indented lines 533-560 to be inside the for-loop
- All log processing now happens for each line
- Proper loop structure restored: for line in recent_lines: if not line: continue if level filter: continue parse and append log entry

Testing:
- python3 -m py_compile verified on all .py files
- No syntax errors remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)