### PR TITLE
Fix critical installation bugs: auto-login and duplicate client startup

### DIFF
--- a/src/DigitalSignage.Client.RaspberryPi/enable-autologin-x11.sh
+++ b/src/DigitalSignage.Client.RaspberryPi/enable-autologin-x11.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
 #
-# Enable Automatic X11 Start on Raspberry Pi OS
-# For production Digital Signage deployments with physical displays
+# DEPRECATED: This script is no longer needed!
+# The install.sh script now handles all auto-login and X11 configuration automatically.
+#
+# Please use: sudo ./install.sh
+#
+# This script is kept for backward compatibility but should not be used for new installations.
 #
 
 echo "========================================================================"
-echo "Raspberry Pi Digital Signage - X11 Auto-Start Setup"
+echo "DEPRECATED SCRIPT"
 echo "========================================================================"
+echo ""
+echo "WARNING: This script (enable-autologin-x11.sh) is deprecated!"
+echo ""
+echo "The install.sh script now handles all auto-login configuration automatically."
+echo "Please run: sudo ./install.sh"
+echo ""
+echo "Do you want to continue anyway? (NOT recommended) [y/N]: "
+read -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted. Please run: sudo ./install.sh"
+    exit 0
+fi
 echo ""
 
 # Check if running as root


### PR DESCRIPTION
CRITICAL FIXES:
1. Remove duplicate client startup mechanism
   - LXDE autostart was starting client in addition to systemd service
   - This caused two simultaneous instances of the client
   - Now systemd service is the ONLY startup mechanism
   - LXDE autostart now only configures display settings (xset, unclutter)

2. Fix .xinitrc to only start LXDE, not the client
   - Previously started client directly in .xinitrc
   - Now only starts LXDE desktop environment
   - systemd service handles client startup

3. Mark enable-autologin-x11.sh as DEPRECATED
   - install.sh now handles all auto-login configuration
   - Added warning to prevent confusion

TECHNICAL DETAILS:
- systemd service waits for X11 (up to 30s) before starting client
- Auto-login configured via raspi-config B4 (Desktop Autologin)
- LXDE autostart disables terminal and desktop icons
- Single point of control: digitalsignage-client.service

This fixes the boot issue where the service file on the Pi has syntax errors (unbalanced quotes) from an older version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)