### PR TITLE
Fix: Add missing Server→Client message types to deserialization

### DIFF
--- a/src/DigitalSignage.Server/Services/WebSocketCommunicationService.cs
+++ b/src/DigitalSignage.Server/Services/WebSocketCommunicationService.cs
@@ -633,7 +633,11 @@ public class WebSocketCommunicationService : ICommunicationService, IDisposable
         {
             return messageType switch
             {
-                // Mobile App → Server messages
+                // ============================================
+                // MOBILE APP ↔ SERVER MESSAGES
+                // ============================================
+
+                // Mobile App → Server
                 MobileAppMessageTypes.AppRegister => JsonConvert.DeserializeObject<AppRegisterMessage>(messageJson, settings),
                 MobileAppMessageTypes.AppHeartbeat => JsonConvert.DeserializeObject<AppHeartbeatMessage>(messageJson, settings),
                 MobileAppMessageTypes.RequestClientList => JsonConvert.DeserializeObject<RequestClientListMessage>(messageJson, settings),
@@ -642,13 +646,35 @@ public class WebSocketCommunicationService : ICommunicationService, IDisposable
                 MobileAppMessageTypes.RequestScreenshot => JsonConvert.DeserializeObject<RequestScreenshotMessage>(messageJson, settings),
                 MobileAppMessageTypes.RequestLayoutList => JsonConvert.DeserializeObject<RequestLayoutListMessage>(messageJson, settings),
 
-                // Device → Server messages (Raspberry Pi clients)
+                // Server → Mobile App
+                MobileAppMessageTypes.AppAuthorizationRequired => JsonConvert.DeserializeObject<AppAuthorizationRequiredMessage>(messageJson, settings),
+                MobileAppMessageTypes.AppAuthorized => JsonConvert.DeserializeObject<AppAuthorizedMessage>(messageJson, settings),
+                MobileAppMessageTypes.AppRejected => JsonConvert.DeserializeObject<AppRejectedMessage>(messageJson, settings),
+                MobileAppMessageTypes.ClientListUpdate => JsonConvert.DeserializeObject<ClientListUpdateMessage>(messageJson, settings),
+                MobileAppMessageTypes.ClientStatusChanged => JsonConvert.DeserializeObject<ClientStatusChangedMessage>(messageJson, settings),
+                MobileAppMessageTypes.ScreenshotResponse => JsonConvert.DeserializeObject<ScreenshotResponseMessage>(messageJson, settings),
+                MobileAppMessageTypes.LayoutListResponse => JsonConvert.DeserializeObject<LayoutListResponseMessage>(messageJson, settings),
+                MobileAppMessageTypes.CommandResult => JsonConvert.DeserializeObject<CommandResultMessage>(messageJson, settings),
+
+                // ============================================
+                // DEVICE (RASPBERRY PI) ↔ SERVER MESSAGES
+                // ============================================
+
+                // Device → Server
                 MessageTypes.Register => JsonConvert.DeserializeObject<RegisterMessage>(messageJson, settings),
                 MessageTypes.Heartbeat => JsonConvert.DeserializeObject<HeartbeatMessage>(messageJson, settings),
                 MessageTypes.StatusReport => JsonConvert.DeserializeObject<StatusReportMessage>(messageJson, settings),
                 MessageTypes.Screenshot => JsonConvert.DeserializeObject<ScreenshotMessage>(messageJson, settings),
                 MessageTypes.Log => JsonConvert.DeserializeObject<LogMessage>(messageJson, settings),
                 MessageTypes.UpdateConfigResponse => JsonConvert.DeserializeObject<UpdateConfigResponseMessage>(messageJson, settings),
+
+                // Server → Device
+                MessageTypes.RegistrationResponse => JsonConvert.DeserializeObject<RegistrationResponseMessage>(messageJson, settings),
+                MessageTypes.DisplayUpdate => JsonConvert.DeserializeObject<DisplayUpdateMessage>(messageJson, settings),
+                MessageTypes.Command => JsonConvert.DeserializeObject<CommandMessage>(messageJson, settings),
+                MessageTypes.UpdateConfig => JsonConvert.DeserializeObject<UpdateConfigMessage>(messageJson, settings),
+                MessageTypes.LayoutAssigned => JsonConvert.DeserializeObject<LayoutAssignmentMessage>(messageJson, settings),
+                MessageTypes.DataUpdate => JsonConvert.DeserializeObject<DataUpdateMessage>(messageJson, settings),
 
                 _ => null
             };


### PR DESCRIPTION
PROBLEM:
Layout-Zuweisung (layout assignment) funktionierte nicht mehr nach dem letzten Commit. Fehlermeldung: Message type konnte nicht deserialisiert werden.

ROOT CAUSE:
In DeserializeMessageByType() fehlten wichtige Server→Client Message-Typen:
- LayoutAssignmentMessage (LAYOUT_ASSIGNED) ← KRITISCH!
- DataUpdateMessage (DATA_UPDATE)
- RegistrationResponseMessage (REGISTRATION_RESPONSE)
- DisplayUpdateMessage (DISPLAY_UPDATE)
- CommandMessage (COMMAND)
- UpdateConfigMessage (UPDATE_CONFIG)

Außerdem fehlten alle Server→Mobile App Nachrichten:
- AppAuthorizationRequiredMessage
- AppAuthorizedMessage
- AppRejectedMessage
- ClientListUpdateMessage
- ClientStatusChangedMessage
- ScreenshotResponseMessage
- LayoutListResponseMessage
- CommandResultMessage

LÖSUNG:
Alle fehlenden Message-Typen zur DeserializeMessageByType() Methode hinzugefügt. Jetzt werden ALLE 27 Message-Typen korrekt deserialisiert:

Mobile App ↔ Server: 15 Typen
Device ↔ Server: 12 Typen

CHANGES:
- WebSocketCommunicationService.cs:630-687
  - Hinzugefügt: 14 fehlende Message-Typen
  - Besser strukturiert mit Kommentaren
  - Vollständige Abdeckung aller Kommunikationspfade

Layout-Zuweisung funktioniert jetzt wieder! ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)