### PR TITLE
UI: Make Mobile App approval buttons more visible

### DIFF
--- a/src/DigitalSignage.Server/Views/MobileAppManagementView.xaml
+++ b/src/DigitalSignage.Server/Views/MobileAppManagementView.xaml
@@ -262,28 +262,36 @@
 
                 <!-- Actions -->
                 <StackPanel Grid.Row="3" Orientation="Horizontal">
-                    <Button Content="✓ Approve"
+                    <Button Content="✓ APPROVE"
                             Command="{Binding ApproveCommand}"
-                            Background="#4CAF50"
+                            Background="#0078D4"
                             Foreground="White"
+                            FontWeight="Bold"
+                            FontSize="14"
                             Style="{StaticResource ActionButton}"/>
 
-                    <Button Content="✗ Reject"
+                    <Button Content="✗ REJECT"
                             Command="{Binding RejectCommand}"
-                            Background="#F44336"
+                            Background="#D13438"
                             Foreground="White"
+                            FontWeight="Bold"
+                            FontSize="14"
                             Style="{StaticResource ActionButton}"/>
 
-                    <Button Content="⊘ Revoke"
+                    <Button Content="⊘ REVOKE"
                             Command="{Binding RevokeCommand}"
-                            Background="#FF9800"
+                            Background="#CA5010"
                             Foreground="White"
+                            FontWeight="Bold"
+                            FontSize="14"
                             Style="{StaticResource ActionButton}"/>
 
-                    <Button Content="🗑 Delete"
+                    <Button Content="🗑 DELETE"
                             Command="{Binding DeleteCommand}"
-                            Background="#9E9E9E"
+                            Background="#424242"
                             Foreground="White"
+                            FontWeight="Bold"
+                            FontSize="14"
                             Style="{StaticResource ActionButton}"/>
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
PROBLEM:
User reports buttons are not visible/clickable in Mobile App Registrations tab.

CHANGES:
- Changed button colors to be more prominent:
  - APPROVE: Blue (#0078D4) instead of green - more professional
  - REJECT: Dark red (#D13438) instead of bright red
  - REVOKE: Orange (#CA5010)
  - DELETE: Dark gray (#424242) instead of light gray

- Made text UPPERCASE for better visibility
- Increased font size from 13px to 14px
- Made font weight Bold
- All buttons now have high contrast white text

Buttons should now be clearly visible and easy to click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)