### PR TITLE
Refactor: Implement Message Handler Pattern for Pi client messages

### DIFF
--- a/src/DigitalSignage.Server/App.xaml.cs
+++ b/src/DigitalSignage.Server/App.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using DigitalSignage.Server.ViewModels;
 using DigitalSignage.Server.Services;
+using DigitalSignage.Server.MessageHandlers;
 using DigitalSignage.Server.Configuration;
 using DigitalSignage.Server.Helpers;
 using DigitalSignage.Core.Interfaces;
@@ -256,7 +257,7 @@ For detailed diagnostics, run:
             // Step 7: Register event handlers
             await progressManager.ExecuteStepAsync(() =>
             {
-                MessageHandlerService.ScreenshotReceived += OnScreenshotReceived;
+                ScreenshotMessageHandler.ScreenshotReceived += OnScreenshotReceived;
                 Log.Information("Screenshot event handler registered");
             });
 
@@ -338,7 +339,7 @@ Common Solutions:
     protected override async void OnExit(ExitEventArgs e)
     {
         // Unsubscribe from screenshot events
-        MessageHandlerService.ScreenshotReceived -= OnScreenshotReceived;
+        ScreenshotMessageHandler.ScreenshotReceived -= OnScreenshotReceived;
 
         if (_host != null)
         {

--- a/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
+++ b/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using DigitalSignage.Core.Interfaces;
 using DigitalSignage.Data;
 using DigitalSignage.Data.Services;
 using DigitalSignage.Server.Helpers;
+using DigitalSignage.Server.MessageHandlers;
 using DigitalSignage.Server.Services;
 using DigitalSignage.Server.ViewModels;
 using Microsoft.EntityFrameworkCore;
@@ -161,6 +162,17 @@ public static class ServiceCollectionExtensions
         // Caching
         services.AddMemoryCache();
         services.AddSingleton<StartupCacheService>();
+
+        // Message Handlers (Handler Pattern for WebSocket messages)
+        services.AddTransient<IMessageHandler, RegisterMessageHandler>();
+        services.AddTransient<IMessageHandler, HeartbeatMessageHandler>();
+        services.AddTransient<IMessageHandler, StatusReportMessageHandler>();
+        services.AddTransient<IMessageHandler, ScreenshotMessageHandler>();
+        services.AddTransient<IMessageHandler, LogMessageHandler>();
+        services.AddTransient<IMessageHandler, UpdateConfigResponseMessageHandler>();
+
+        // Message Handler Factory
+        services.AddSingleton<MessageHandlerFactory>();
 
         return services;
     }

--- a/src/DigitalSignage.Server/MessageHandlers/AppRegisterMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/AppRegisterMessageHandler.cs
@@ -1,0 +1,84 @@
+using DigitalSignage.Core.Interfaces;
+using DigitalSignage.Core.Models;
+using DigitalSignage.Server.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DigitalSignage.Server.MessageHandlers;
+
+/// <summary>
+/// Handles AppRegister messages from mobile apps
+/// </summary>
+public class AppRegisterMessageHandler : MessageHandlerBase
+{
+    private readonly ILogger<AppRegisterMessageHandler> _logger;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ConcurrentDictionary<string, SslWebSocketConnection> _mobileAppConnections;
+    private readonly ConcurrentDictionary<string, Guid> _mobileAppIds;
+    private readonly ConcurrentDictionary<string, string> _mobileAppTokens;
+
+    public override string MessageType => MobileAppMessageTypes.AppRegister;
+
+    public AppRegisterMessageHandler(
+        ILogger<AppRegisterMessageHandler> logger,
+        IServiceProvider serviceProvider,
+        ConcurrentDictionary<string, SslWebSocketConnection> mobileAppConnections,
+        ConcurrentDictionary<string, Guid> mobileAppIds,
+        ConcurrentDictionary<string, string> mobileAppTokens)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _mobileAppConnections = mobileAppConnections ?? throw new ArgumentNullException(nameof(mobileAppConnections));
+        _mobileAppIds = mobileAppIds ?? throw new ArgumentNullException(nameof(mobileAppIds));
+        _mobileAppTokens = mobileAppTokens ?? throw new ArgumentNullException(nameof(mobileAppTokens));
+    }
+
+    public override async Task HandleAsync(Message message, string connectionId, CancellationToken cancellationToken = default)
+    {
+        if (message is not AppRegisterMessage appRegisterMsg)
+        {
+            _logger.LogWarning("Invalid message type for AppRegisterMessageHandler");
+            return;
+        }
+
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var mobileAppService = scope.ServiceProvider.GetRequiredService<IMobileAppService>();
+
+            var result = await mobileAppService.RegisterAppAsync(
+                appRegisterMsg.DeviceName,
+                appRegisterMsg.DeviceIdentifier,
+                appRegisterMsg.AppVersion,
+                appRegisterMsg.Platform);
+
+            if (result.IsSuccess)
+            {
+                var registration = result.Value;
+
+                // Track mobile app connection
+                _mobileAppIds[connectionId] = registration.Id;
+
+                _logger.LogInformation("Mobile app registered: {DeviceName} ({Platform}), ID={AppId}",
+                    appRegisterMsg.DeviceName, appRegisterMsg.Platform, registration.Id);
+
+                // Send appropriate response based on status
+                // Note: Sending is handled by the calling service since this handler doesn't have direct access to connection
+            }
+            else
+            {
+                _logger.LogWarning("Mobile app registration failed: {Error}", result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during mobile app registration for connection {ConnectionId}", connectionId);
+        }
+    }
+}

--- a/src/DigitalSignage.Server/MessageHandlers/LogMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/LogMessageHandler.cs
@@ -1,0 +1,74 @@
+using DigitalSignage.Core.Interfaces;
+using DigitalSignage.Core.Models;
+using DigitalSignage.Server.Services;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DigitalSignage.Server.MessageHandlers;
+
+/// <summary>
+/// Handles Log messages from Pi clients
+/// Moved from MessageHandlerService.HandleLogMessageAsync
+/// </summary>
+public class LogMessageHandler : MessageHandlerBase
+{
+    private readonly ILogger<LogMessageHandler> _logger;
+    private readonly IClientService _clientService;
+    private readonly LogStorageService _logStorageService;
+
+    public override string MessageType => MessageTypes.Log;
+
+    public LogMessageHandler(
+        ILogger<LogMessageHandler> logger,
+        IClientService clientService,
+        LogStorageService logStorageService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
+        _logStorageService = logStorageService ?? throw new ArgumentNullException(nameof(logStorageService));
+    }
+
+    public override async Task HandleAsync(Message message, string connectionId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var logMessage = message as Core.Models.LogMessage;
+            if (logMessage != null)
+            {
+                // Get client info for better log display
+                var clientResult = await _clientService.GetClientByIdAsync(logMessage.ClientId);
+                var client = clientResult.IsSuccess ? clientResult.Value : null;
+
+                var logEntry = new LogEntry
+                {
+                    ClientId = logMessage.ClientId,
+                    ClientName = client?.Name ?? logMessage.ClientId,
+                    Timestamp = logMessage.Timestamp,
+                    Level = logMessage.Level,
+                    Message = logMessage.Message,
+                    Exception = logMessage.Exception,
+                    Source = "Client"
+                };
+
+                _logStorageService.AddLog(logEntry);
+
+                // Also log to server logs if it's warning or error
+                // Skip asyncio internal errors as they're handled by the client
+                bool isAsyncioInternalError = logMessage.Message?.Contains("Exception in callback") == true
+                    || logMessage.Message?.Contains("_asyncio.TaskStepMethWrapper") == true;
+
+                if (logMessage.Level >= Core.Models.LogLevel.Warning && !isAsyncioInternalError)
+                {
+                    _logger.LogWarning("Client {ClientId} [{Level}]: {Message}",
+                        logMessage.ClientId, logMessage.Level, logMessage.Message);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling LOG message from client {ClientId}", connectionId);
+        }
+    }
+}

--- a/src/DigitalSignage.Server/MessageHandlers/MessageHandlerFactory.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/MessageHandlerFactory.cs
@@ -32,21 +32,23 @@ public class MessageHandlerFactory
     /// </summary>
     private void RegisterHandlers()
     {
-        // Register device message handlers
+        // Register Pi client message handlers
         RegisterHandler<RegisterMessageHandler>();
         RegisterHandler<HeartbeatMessageHandler>();
-        // Add more handlers as they are created:
-        // RegisterHandler<StatusReportMessageHandler>();
-        // RegisterHandler<ScreenshotMessageHandler>();
-        // RegisterHandler<LogMessageHandler>();
+        RegisterHandler<StatusReportMessageHandler>();
+        RegisterHandler<ScreenshotMessageHandler>();
+        RegisterHandler<LogMessageHandler>();
+        RegisterHandler<UpdateConfigResponseMessageHandler>();
 
-        // Register mobile app message handlers
+        // Mobile app message handlers - not yet migrated (still in WebSocketCommunicationService)
         // RegisterHandler<AppRegisterMessageHandler>();
         // RegisterHandler<AppHeartbeatMessageHandler>();
         // RegisterHandler<RequestClientListMessageHandler>();
         // RegisterHandler<SendCommandMessageHandler>();
 
-        _logger.LogInformation("Registered {Count} message handlers", _handlerTypes.Count);
+        _logger.LogInformation("Registered {Count} message handlers: {MessageTypes}",
+            _handlerTypes.Count,
+            string.Join(", ", _handlerTypes.Keys));
     }
 
     /// <summary>

--- a/src/DigitalSignage.Server/MessageHandlers/ScreenshotMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/ScreenshotMessageHandler.cs
@@ -1,0 +1,88 @@
+using DigitalSignage.Core.Interfaces;
+using DigitalSignage.Core.Models;
+using DigitalSignage.Server.Services;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DigitalSignage.Server.MessageHandlers;
+
+/// <summary>
+/// Handles Screenshot messages from Pi clients
+/// Moved from MessageHandlerService.HandleScreenshotMessageAsync
+/// </summary>
+public class ScreenshotMessageHandler : MessageHandlerBase
+{
+    private readonly ILogger<ScreenshotMessageHandler> _logger;
+    private readonly IClientService _clientService;
+
+    public override string MessageType => MessageTypes.Screenshot;
+
+    /// <summary>
+    /// Event raised when a screenshot is received from a client
+    /// </summary>
+    public static event EventHandler<ScreenshotReceivedEventArgs>? ScreenshotReceived;
+
+    public ScreenshotMessageHandler(
+        ILogger<ScreenshotMessageHandler> logger,
+        IClientService clientService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
+    }
+
+    public override async Task HandleAsync(Message message, string connectionId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("=== HandleScreenshotMessageAsync START ===");
+
+            var screenshotMessage = message as ScreenshotMessage;
+            if (screenshotMessage != null)
+            {
+                _logger.LogInformation("Screenshot message deserialized successfully");
+                _logger.LogInformation("ClientId: {ClientId}", screenshotMessage.ClientId);
+                _logger.LogInformation("ImageData length: {Length} characters", screenshotMessage.ImageData?.Length ?? 0);
+                _logger.LogInformation("Format: {Format}", screenshotMessage.Format);
+
+                // Get client name for better display
+                var clientResult = await _clientService.GetClientByIdAsync(screenshotMessage.ClientId);
+                var clientName = clientResult.IsSuccess && clientResult.Value != null
+                    ? clientResult.Value.Name
+                    : screenshotMessage.ClientId;
+                _logger.LogInformation("Client name resolved: {ClientName}", clientName);
+
+                // Raise event to notify UI
+                if (!string.IsNullOrWhiteSpace(screenshotMessage.ImageData))
+                {
+                    var eventArgs = new ScreenshotReceivedEventArgs
+                    {
+                        ClientId = screenshotMessage.ClientId,
+                        ClientName = clientName,
+                        ImageData = screenshotMessage.ImageData,
+                        Format = screenshotMessage.Format
+                    };
+
+                    _logger.LogInformation("Invoking ScreenshotReceived event...");
+                    ScreenshotReceived?.Invoke(this, eventArgs);
+                    _logger.LogInformation("Screenshot event raised successfully for client {ClientName}", clientName);
+                }
+                else
+                {
+                    _logger.LogWarning("Screenshot from client {ClientId} has no image data", screenshotMessage.ClientId);
+                }
+            }
+            else
+            {
+                _logger.LogError("Failed to deserialize screenshot message - result was null");
+            }
+
+            _logger.LogInformation("=== HandleScreenshotMessageAsync END ===");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "=== HandleScreenshotMessageAsync FAILED === Error handling SCREENSHOT message from client {ClientId}", connectionId);
+        }
+    }
+}

--- a/src/DigitalSignage.Server/MessageHandlers/StatusReportMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/StatusReportMessageHandler.cs
@@ -1,0 +1,53 @@
+using DigitalSignage.Core.Interfaces;
+using DigitalSignage.Core.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DigitalSignage.Server.MessageHandlers;
+
+/// <summary>
+/// Handles StatusReport messages from Pi clients
+/// Moved from MessageHandlerService.HandleStatusReportMessageAsync
+/// </summary>
+public class StatusReportMessageHandler : MessageHandlerBase
+{
+    private readonly ILogger<StatusReportMessageHandler> _logger;
+    private readonly IClientService _clientService;
+
+    public override string MessageType => MessageTypes.StatusReport;
+
+    public StatusReportMessageHandler(
+        ILogger<StatusReportMessageHandler> logger,
+        IClientService clientService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
+    }
+
+    public override async Task HandleAsync(Message message, string connectionId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var statusMessage = message as StatusReportMessage;
+            if (statusMessage != null)
+            {
+                await _clientService.UpdateClientStatusAsync(
+                    statusMessage.ClientId,
+                    statusMessage.Status,
+                    statusMessage.DeviceInfo);
+
+                if (!string.IsNullOrEmpty(statusMessage.ErrorMessage))
+                {
+                    _logger.LogWarning("Client {ClientId} reported error: {Error}",
+                        statusMessage.ClientId, statusMessage.ErrorMessage);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling STATUS_REPORT message from client {ClientId}", connectionId);
+        }
+    }
+}

--- a/src/DigitalSignage.Server/MessageHandlers/UpdateConfigResponseMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/UpdateConfigResponseMessageHandler.cs
@@ -1,0 +1,51 @@
+using DigitalSignage.Core.Interfaces;
+using DigitalSignage.Core.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DigitalSignage.Server.MessageHandlers;
+
+/// <summary>
+/// Handles UpdateConfigResponse messages from Pi clients
+/// Moved from MessageHandlerService.HandleUpdateConfigResponseAsync
+/// </summary>
+public class UpdateConfigResponseMessageHandler : MessageHandlerBase
+{
+    private readonly ILogger<UpdateConfigResponseMessageHandler> _logger;
+
+    public override string MessageType => MessageTypes.UpdateConfigResponse;
+
+    public UpdateConfigResponseMessageHandler(ILogger<UpdateConfigResponseMessageHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public override Task HandleAsync(Message message, string connectionId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var responseMessage = message as UpdateConfigResponseMessage;
+            if (responseMessage != null)
+            {
+                if (responseMessage.Success)
+                {
+                    _logger.LogInformation("Client {ClientId} successfully updated configuration", connectionId);
+                }
+                else
+                {
+                    _logger.LogWarning("Client {ClientId} failed to update configuration: {Error}",
+                        connectionId,
+                        responseMessage.ErrorMessage ?? "Unknown error");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling UPDATE_CONFIG_RESPONSE message from client {ClientId}", connectionId);
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
MAJOR REFACTORING - Handler Pattern Implementation:

✅ Created 6 Pi Client Message Handlers:
- RegisterMessageHandler (from MessageHandlerService.HandleRegisterMessageAsync)
- HeartbeatMessageHandler (from MessageHandlerService.HandleHeartbeatMessageAsync)
- StatusReportMessageHandler (from MessageHandlerService.HandleStatusReportMessageAsync)
- ScreenshotMessageHandler (from MessageHandlerService.HandleScreenshotMessageAsync + static event)
- LogMessageHandler (from MessageHandlerService.HandleLogMessageAsync)
- UpdateConfigResponseMessageHandler (from MessageHandlerService.HandleUpdateConfigResponseAsync)

✅ Updated MessageHandlerFactory:
- Registered all 6 Pi client handlers
- Added logging for registered message types

✅ Updated WebSocketCommunicationService:
- Added MessageHandlerFactory dependency injection
- ProcessClientMessageAsync now uses handler pattern for Pi client messages
- Preserved CRITICAL UpdateClientId sequencing for RegisterMessage
- Handlers called directly instead of firing MessageReceived event
- Fallback to MessageReceived event for unknown message types (gradual migration)
- Mobile app messages still use HandleMobileAppMessageAsync (migration pending)

✅ Updated Dependency Injection (ServiceCollectionExtensions.cs):
- Registered all 6 message handlers as IMessageHandler (Transient)
- Registered MessageHandlerFactory (Singleton)

✅ Updated Event Subscriptions (App.xaml.cs):
- Changed from MessageHandlerService.ScreenshotReceived
- To ScreenshotMessageHandler.ScreenshotReceived (static event)

BENEFITS:
✓ Modular message handling (each handler is independent) ✓ Testable in isolation (handlers can be unit tested) ✓ Single Responsibility Principle (one handler per message type) ✓ Factory Pattern for handler creation
✓ Dependency Injection for all handlers
✓ Maintains backward compatibility (MessageReceived event still works)

MIGRATION STATUS:
✅ Pi client messages (REGISTER, HEARTBEAT, STATUS_REPORT, SCREENSHOT, LOG, UPDATE_CONFIG_RESPONSE) ⏳ Mobile app messages (still in WebSocketCommunicationService - 500 lines, future PR)

LINE COUNT:
- WebSocketCommunicationService.cs: 1534 lines (was 1519)
- Added handler infrastructure but extracted business logic
- Mobile app handling (~500 lines) remains for future refactoring

TECHNICAL NOTES:
- UpdateClientId MUST happen BEFORE handler.HandleAsync() for RegisterMessage
- ScreenshotMessageHandler uses static event for UI notification
- Handlers are Transient (created per request)
- Factory is Singleton (created once)

🤖 Generated with Claude Code (https://claude.com/claude-code)