### PR TITLE
Integrate message versioning for protocol compatibility

### DIFF
--- a/src/DigitalSignage.Core/Models/Messages.cs
+++ b/src/DigitalSignage.Core/Models/Messages.cs
@@ -9,6 +9,12 @@ public abstract class Message
     public string Type { get; set; } = string.Empty;
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
     public string SenderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Protocol version (Semantic Versioning: MAJOR.MINOR.PATCH)
+    /// Optional for backward compatibility with legacy clients
+    /// </summary>
+    public string? Version { get; set; }
 }
 
 /// <summary>

--- a/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
+++ b/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
@@ -171,6 +171,9 @@ public static class ServiceCollectionExtensions
         // Mobile App Connection Manager
         services.AddSingleton<MobileAppConnectionManager>();
 
+        // Message Versioning
+        services.AddSingleton<MessageVersionValidator>();
+
         // Message Handlers (Handler Pattern for WebSocket messages)
         // Pi Client Message Handlers
         services.AddTransient<IMessageHandler, RegisterMessageHandler>();


### PR DESCRIPTION
✅ Message Versioning Integration:
- Added Version field to Message base class (optional for backward compatibility)
- Registered MessageVersionValidator in DI container
- Integrated version validation in WebSocketCommunicationService:
  * Validates incoming message versions
  * Adds version to all outgoing messages (SendMessageAsync, BroadcastMessageAsync)
  * Closes incompatible connections with error message
  * Cleans up version cache on disconnect
- Supports legacy clients without version (assumes v1.0.0)
- Current server version: 1.0.0
- Minimum supported version: 1.0.0

🎯 Benefits:
- Protocol version compatibility tracking
- Graceful handling of version mismatches
- Client upgrade notifications
- Future-proof for protocol evolution

📝 Technical Details:
- Semantic Versioning (MAJOR.MINOR.PATCH)
- Thread-safe version cache (ConcurrentDictionary)
- Backward compatible (version optional)
- Detailed logging for monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)