### PR TITLE
Fix build errors: Remove merge conflict and add platform versions

### DIFF
--- a/src/DigitalSignage.App.Mobile/DigitalSignage.App.Mobile.csproj
+++ b/src/DigitalSignage.App.Mobile/DigitalSignage.App.Mobile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-ios;net8.0-android;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0-ios17.5;net8.0-android34.0;net8.0-maccatalyst17.5</TargetFrameworks>
 		<!-- Uncomment to also build Windows target on Windows -->
 		<!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks> -->
 

--- a/src/DigitalSignage.Server/Services/WebSocketCommunicationService.cs
+++ b/src/DigitalSignage.Server/Services/WebSocketCommunicationService.cs
@@ -1025,4 +1025,3 @@ public class WebSocketCommunicationService : ICommunicationService, IDisposable
         _disposed = true;
     }
 }
-=======


### PR DESCRIPTION
- Remove merge conflict marker (=======) from WebSocketCommunicationService.cs:1028
- Fix NU1012 error: Add platform versions to mobile project target frameworks
  * net8.0-ios → net8.0-ios17.5
  * net8.0-android → net8.0-android34.0
  * net8.0-maccatalyst → net8.0-maccatalyst17.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)