### PR TITLE
Fix 7 build errors in DigitalSignage.Server

### DIFF
--- a/src/DigitalSignage.Server/Helpers/MessageValidationHelper.cs
+++ b/src/DigitalSignage.Server/Helpers/MessageValidationHelper.cs
@@ -104,10 +104,10 @@ public class MessageValidationHelper
             return ValidationResult.Failure("ClientId is required");
         }
 
-        if (string.IsNullOrWhiteSpace(message.Token))
+        if (string.IsNullOrWhiteSpace(message.RegistrationToken))
         {
-            _logger.LogWarning("RegisterMessage missing Token from {ConnectionId}", connectionId);
-            return ValidationResult.Failure("Token is required");
+            _logger.LogWarning("RegisterMessage missing RegistrationToken from {ConnectionId}", connectionId);
+            return ValidationResult.Failure("RegistrationToken is required");
         }
 
         return ValidationResult.Success();

--- a/src/DigitalSignage.Server/MessageHandlers/MobileApp/AppHeartbeatMessageHandler.cs
+++ b/src/DigitalSignage.Server/MessageHandlers/MobileApp/AppHeartbeatMessageHandler.cs
@@ -1,5 +1,6 @@
 using DigitalSignage.Core.Interfaces;
 using DigitalSignage.Core.Models;
+using DigitalSignage.Server.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/DigitalSignage.Server/Services/ClientService.cs
+++ b/src/DigitalSignage.Server/Services/ClientService.cs
@@ -42,6 +42,7 @@ public class ClientService : IClientService, IDisposable
         ILayoutService layoutService,
         ISqlDataService dataService,
         IScribanService scribanService,
+        AsyncLockService lockService,
         IServiceProvider serviceProvider,
         ILogger<ClientService> logger)
     {
@@ -60,7 +61,8 @@ public class ClientService : IClientService, IDisposable
             serviceProvider,
             registrationLogger,
             communicationService,
-            layoutService);
+            layoutService,
+            lockService);
 
         _layoutDistributor = new ClientLayoutDistributor(
             serviceProvider,

--- a/src/DigitalSignage.Server/Services/MobileAppService.cs
+++ b/src/DigitalSignage.Server/Services/MobileAppService.cs
@@ -223,24 +223,23 @@ public class MobileAppService : IMobileAppService
             // This prevents the app from being stuck in "Waiting for approval" state
             try
             {
-                // CRITICAL: Must get concrete WebSocketCommunicationService class (NOT ICommunicationService)
-                // because SendRejectionNotificationAsync() is specific to WebSocket implementation
-                var webSocketService = _serviceProvider.GetService<WebSocketCommunicationService>();
+                // Get MobileAppConnectionManager to send rejection notification
+                var connectionManager = _serviceProvider.GetService<MobileAppConnectionManager>();
 
-                if (webSocketService != null)
+                if (connectionManager != null)
                 {
                     _logger.Information("Sending rejection notification to mobile app {AppId} via WebSocket", appId);
 
                     // Send rejection notification to iOS App
-                    // The WebSocketCommunicationService will find the connection by MobileAppId
-                    await webSocketService.SendRejectionNotificationAsync(appId, reason);
+                    // The MobileAppConnectionManager will find the connection by MobileAppId
+                    await connectionManager.SendRejectionNotificationAsync(appId, reason);
 
                     _logger.Information("✓ Rejection notification sent successfully to mobile app {AppId} via WebSocket", appId);
                 }
                 else
                 {
-                    _logger.Error("CRITICAL ERROR: WebSocketCommunicationService not available in DI container - mobile app cannot receive rejection notification!");
-                    _logger.Error("Check ServiceCollectionExtensions.AddBusinessServices() - WebSocketCommunicationService must be registered as concrete class");
+                    _logger.Error("CRITICAL ERROR: MobileAppConnectionManager not available in DI container - mobile app cannot receive rejection notification!");
+                    _logger.Error("Check ServiceCollectionExtensions.AddBusinessServices() - MobileAppConnectionManager must be registered");
                 }
             }
             catch (Exception wsEx)


### PR DESCRIPTION
Fixed the following compilation errors:

1. CS1061: RegisterMessage.Token → RegisterMessage.RegistrationToken
   - Updated MessageValidationHelper.cs to use correct property name

2. CS0246: Added missing using for IMobileAppService
   - Added using DigitalSignage.Server.Services to AppHeartbeatMessageHandler.cs

3. CS7036: Added missing lockService parameter
   - Updated ClientService constructor to inject AsyncLockService
   - Passed lockService to ClientRegistrationHandler constructor

4. CS1061: Implemented SendRejectionNotificationAsync
   - Added SendRejectionNotificationAsync method to MobileAppConnectionManager
   - Updated MobileAppService to use MobileAppConnectionManager instead of WebSocketCommunicationService

5. CS0103: Removed invalid DisconnectClientAsync call
   - Connection cleanup is already handled in HandleWebSocketConnectionAsync finally block

6-7. CS0103: Fixed SendErrorAsync calls
   - Updated WebSocketCommunicationService to use MobileAppConnectionManager.SendErrorAsync
   - Properly pass connectionId instead of connection object

All errors related to refactoring to Handler Pattern and MobileAppConnectionManager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)