### PR TITLE
Fix message handler registration for mobile app

### DIFF
--- a/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
+++ b/src/DigitalSignage.Server/Configuration/ServiceCollectionExtensions.cs
@@ -179,20 +179,35 @@ public static class ServiceCollectionExtensions
 
         // Message Handlers (Handler Pattern for WebSocket messages)
         // Pi Client Message Handlers
+        // NOTE: Register both concrete type AND interface so MessageHandlerFactory can resolve them
+        services.AddTransient<RegisterMessageHandler>();
         services.AddTransient<IMessageHandler, RegisterMessageHandler>();
+        services.AddTransient<HeartbeatMessageHandler>();
         services.AddTransient<IMessageHandler, HeartbeatMessageHandler>();
+        services.AddTransient<StatusReportMessageHandler>();
         services.AddTransient<IMessageHandler, StatusReportMessageHandler>();
+        services.AddTransient<ScreenshotMessageHandler>();
         services.AddTransient<IMessageHandler, ScreenshotMessageHandler>();
+        services.AddTransient<LogMessageHandler>();
         services.AddTransient<IMessageHandler, LogMessageHandler>();
+        services.AddTransient<UpdateConfigResponseMessageHandler>();
         services.AddTransient<IMessageHandler, UpdateConfigResponseMessageHandler>();
 
         // Mobile App Message Handlers
+        // NOTE: Register both concrete type AND interface so MessageHandlerFactory can resolve them
+        services.AddTransient<MessageHandlers.MobileApp.AppRegisterMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.AppRegisterMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.AppHeartbeatMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.AppHeartbeatMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.RequestClientListMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.RequestClientListMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.SendCommandMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.SendCommandMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.AssignLayoutMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.AssignLayoutMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.RequestScreenshotMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.RequestScreenshotMessageHandler>();
+        services.AddTransient<MessageHandlers.MobileApp.RequestLayoutListMessageHandler>();
         services.AddTransient<IMessageHandler, MessageHandlers.MobileApp.RequestLayoutListMessageHandler>();
 
         // Message Handler Factory


### PR DESCRIPTION
The MessageHandlerFactory was unable to resolve message handlers because they were only registered as IMessageHandler, not as their concrete types. This caused all mobile app messages (APP_REGISTER, APP_HEARTBEAT, etc.) to fail with 'No handler registered' warnings.

Changes:
- Updated ServiceCollectionExtensions.cs to register each handler TWICE:
  1. As concrete type (for MessageHandlerFactory.RegisterHandler)
  2. As IMessageHandler interface (for polymorphic usage)

This fixes the critical bug where mobile apps couldn't connect because the APP_REGISTER handler was not being found.

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)