### PR TITLE
Fix startup hang caused by sync-over-async deadlock in NetworkDiscove…

### DIFF
--- a/src/DigitalSignage.Server/Services/INetworkDiscoveryService.cs
+++ b/src/DigitalSignage.Server/Services/INetworkDiscoveryService.cs
@@ -20,10 +20,10 @@ public interface INetworkDiscoveryService
     /// <summary>
     /// Get current server info
     /// </summary>
-    ServerInfo GetServerInfo();
+    Task<ServerInfo> GetServerInfoAsync();
 
     /// <summary>
     /// Update service advertisement (e.g., when connected clients count changes)
     /// </summary>
-    void UpdateAdvertisement();
+    Task UpdateAdvertisementAsync();
 }

--- a/src/DigitalSignage.Server/Services/NetworkDiscoveryService.cs
+++ b/src/DigitalSignage.Server/Services/NetworkDiscoveryService.cs
@@ -53,7 +53,7 @@ public class NetworkDiscoveryService : BackgroundService, INetworkDiscoveryServi
     {
         try
         {
-            var serverInfo = GetServerInfo();
+            var serverInfo = await GetServerInfoAsync();
 
             // Create service profile
             _serviceProfile = new ServiceProfile(
@@ -114,13 +114,13 @@ public class NetworkDiscoveryService : BackgroundService, INetworkDiscoveryServi
         await Task.CompletedTask;
     }
 
-    public void UpdateAdvertisement()
+    public async Task UpdateAdvertisementAsync()
     {
         try
         {
             if (_serviceProfile != null)
             {
-                var serverInfo = GetServerInfo();
+                var serverInfo = await GetServerInfoAsync();
 
                 // Update TXT records
                 _serviceProfile.Resources.Clear();
@@ -148,7 +148,7 @@ public class NetworkDiscoveryService : BackgroundService, INetworkDiscoveryServi
         }
     }
 
-    public ServerInfo GetServerInfo()
+    public async Task<ServerInfo> GetServerInfoAsync()
     {
         // Get server hostname
         var hostname = Dns.GetHostName();
@@ -177,7 +177,7 @@ public class NetworkDiscoveryService : BackgroundService, INetworkDiscoveryServi
         {
             try
             {
-                var result = _clientService.GetAllClientsAsync().GetAwaiter().GetResult();
+                var result = await _clientService.GetAllClientsAsync();
                 if (result.IsSuccess)
                 {
                     connectedClients = result.Value?.Count(c => c.Status == ClientStatus.Online) ?? 0;


### PR DESCRIPTION
…ryService

- Changed GetServerInfo() to GetServerInfoAsync() to make it properly async
- Changed UpdateAdvertisement() to UpdateAdvertisementAsync()
- Removed blocking .GetAwaiter().GetResult() call that was causing deadlock during host startup
- Updated INetworkDiscoveryService interface to match async signatures

This fixes the hang at 'Starting application host...' during step 1/8 of startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)